### PR TITLE
ODP-2718|ODP-2772 Refactor shebangs for python scripts to ambari-python-wrap

### DIFF
--- a/kafka-merge-pr.py
+++ b/kafka-merge-pr.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/release.py
+++ b/release.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 #
 # Licensed to the Apache Software Foundation (ASF) under one or more

--- a/release_notes.py
+++ b/release_notes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with

--- a/tests/bin/external_trogdor_command_example.py
+++ b/tests/bin/external_trogdor_command_example.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env ambari-python-wrap
 # Licensed to the Apache Software Foundation (ASF) under one or more
 # contributor license agreements.  See the NOTICE file distributed with
 # this work for additional information regarding copyright ownership.


### PR DESCRIPTION
ODP-2718|ODP-2772 Refactor shebangs for python scripts to ambari-python-wrap

Tested in RHEL9, RHEL8, UBUNTU22