### PR TITLE
OSV-6942 - CVE - Upgrade pubsub-group-kafka-connector version to 1.3.2 which in-turn will increase guava version to CVE-2023-2976

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2065,7 +2065,7 @@ project(':connect:runtime') {
 
     testRuntime libs.slf4jlog4j
     implementation 'org.mongodb.kafka:mongo-kafka:2.0.0:all@jar'
-    implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0@jar'
+    implementation 'com.google.cloud:pubsub-group-kafka-connector:1.3.2@jar'
     implementation 'io.aiven:aiven-kafka-connect-s3:2.6.0-8@jar'
     implementation 'io.aiven:aiven-kafka-connect-jdbc:6.1.2-8@jar'
     implementation 'com.amazonaws:amazon-kinesis-kafka-connecter:0.0.8@jar'


### PR DESCRIPTION
Upgrade pubsub-group-kafka-connector version to 1.3.2 which in-turn will increase guava version to CVE-2023-2976