### PR TITLE
OSV-4905 - CVE - Upgrade jetty version to 9.4.57.v20241219 to CVE-2024-9823

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -70,7 +70,7 @@ versions += [
   jacksonDatabind: "2.12.7.1",
   jacoco: "0.8.5",
   javassist: "3.27.0-GA",
-  jetty: "9.4.48.v20220622",
+  jetty: "9.4.57.v20241219",
   jersey: "2.34",
   jline: "3.12.1",
   jmh: "1.27",


### PR DESCRIPTION
Upgrade jetty version to 9.4.57.v20241219 to CVE-2024-9823