### PR TITLE
ODP-6672 : Update Kafka Connect runtime connector dependencies to ODP-3.3.6.4-1 versions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2067,13 +2067,13 @@ project(':connect:runtime') {
     testCompile project(':core').sourceSets.test.output
 
     testRuntime libs.slf4jlog4j
-    implementation 'org.mongodb.kafka:mongo-kafka:2.0.0:all@jar'
-    implementation 'com.google.cloud:pubsub-group-kafka-connector:1.3.2@jar'
-    implementation 'io.aiven:aiven-kafka-connect-s3:2.15.0@jar'
-    implementation 'io.aiven:aiven-kafka-connect-jdbc:6.10.0@jar'
-    implementation 'com.amazonaws:amazon-kinesis-kafka-connecter:0.0.8@jar'
+    implementation 'org.mongodb.kafka:mongo-kafka:1.13.0.3.3.6.4-1:all@jar'
+    implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0.3.3.6.4-1@jar'
+    implementation 'io.aiven:aiven-kafka-connect-s3:2.15.0.3.3.6.4-1@jar'
+    implementation 'io.aiven:aiven-kafka-connect-jdbc:6.10.0.3.3.6.4-1@jar'
+    implementation 'com.amazonaws:amazon-kinesis-kafka-connecter:0.0.8.3.3.6.4-1@jar'
     implementation 'com.linkedin.cruisecontrol:cruise-control-metrics-reporter:2.5.84-11@jar'
-    implementation 'org.apache.camel.kafkaconnector:camel-aws-sqs-sink-kafka-connector:3.21.0:uber-kafka2@jar'
+    implementation 'org.apache.camel.kafkaconnector:camel-aws-sqs-sink-kafka-connector:3.21.0.2.8.2.3.3.6.4-1:uber-kafka2@jar'
   }
 
   javadoc {

--- a/build.gradle
+++ b/build.gradle
@@ -2067,7 +2067,7 @@ project(':connect:runtime') {
     testCompile project(':core').sourceSets.test.output
 
     testRuntime libs.slf4jlog4j
-    implementation 'org.mongodb.kafka:mongo-kafka:1.13.0.3.3.6.4-1:all@jar'
+    implementation 'org.mongodb.kafka:mongo-kafka:2.0.0.3.3.6.4-1:all@jar'
     implementation 'com.google.cloud:pubsub-group-kafka-connector:1.2.0.3.3.6.4-1@jar'
     implementation 'io.aiven:aiven-kafka-connect-s3:2.15.0.3.3.6.4-1@jar'
     implementation 'io.aiven:aiven-kafka-connect-jdbc:6.10.0.3.3.6.4-1@jar'


### PR DESCRIPTION
This patch was tested locally.