### PR TITLE
OSV-22426: Bump netty to 4.1.135.Final (netty 4.1.1* CVEs)

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -98,7 +98,7 @@ versions += [
   mavenArtifact: "3.8.1",
   metrics: "2.2.0",
   mockito: "3.6.0",
-  netty: "4.1.132.Final",
+  netty: "4.1.135.Final",
   owaspDepCheckPlugin: "6.0.3",
   powermock: "2.0.9",
   plexusUtils: "4.0.3",


### PR DESCRIPTION
## Summary
- Bump Netty to **4.1.135.Final** to address CVEs reported against netty **4.1.1\*.Final**.

## Tickets (13)
OSV-21766, OSV-22426, OSV-22427, OSV-22439, OSV-22440, OSV-22441, OSV-22442, OSV-22443, OSV-22444, OSV-22445, OSV-22446, OSV-22451, OSV-22476
