### PR TITLE
OSV-21721 - CVE - Bumped-up Jackson to 2.18.6 to address CVE-2020-8840

### DIFF
--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -66,7 +66,7 @@ versions += [
   grgit: "4.1.1",
   httpclient: "4.5.13",
   easymock: "4.2",
-  jackson: "2.16.2",
+  jackson: "2.18.6",
   jacoco: "0.8.5",
   javassist: "3.27.0-GA",
   jetty: "9.4.57.v20241219",


### PR DESCRIPTION
- Library : Jackson
- Version : -> 2.18.6
- Tickets : OSV-21721, OSV-21722, OSV-21723, OSV-21724, OSV-21725, OSV-21726, OSV-21727, OSV-21728, OSV-21729, OSV-21730, OSV-21731, OSV-21732, OSV-21733, OSV-21734, OSV-21735, OSV-21736, OSV-21737, OSV-21738, OSV-21739, OSV-21740, OSV-21741, OSV-21742, OSV-21743, OSV-21744, OSV-21745, OSV-21746, OSV-21747, OSV-21748, OSV-21749, OSV-21750, OSV-21751, OSV-21752, OSV-21753, OSV-21755, OSV-21762, OSV-21763, OSV-21767, OSV-21768, OSV-21769, OSV-22391, OSV-22392, OSV-22393, OSV-22394, OSV-22395, OSV-22396, OSV-22397, OSV-22398, OSV-22399, OSV-22400, OSV-22401, OSV-22402, OSV-22403, OSV-22404, OSV-22405, OSV-22406, OSV-22407, OSV-22408, OSV-22409, OSV-22410, OSV-22411, OSV-22412, OSV-22413, OSV-22414, OSV-22415, OSV-22416, OSV-22417, OSV-22418, OSV-22419, OSV-22420, OSV-22421, OSV-22422, OSV-22423, OSV-22438, OSV-22452, OSV-22459, OSV-22478, OSV-22479, OSV-22480