### PR TITLE
OSV-21706 - CVE - Bumped-up commons-lang3 to 3.18.0 to address CVE-2025-48924

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,7 @@ allprojects {
           force(
             // be explicit about the javassist dependency version instead of relying on the transitive version
             libs.javassist,
+            "org.apache.commons:commons-lang3:3.18.0",
             // ensure we have a single version in the classpath despite transitive dependencies
             libs.scalaLibrary,
             libs.scalaReflect,


### PR DESCRIPTION
- Component: kafka (nightly/ODP-3.3.6.5, release 3.3.6.4)
- Library: commons-lang3 → 3.18.0
- Tickets: OSV-21706
- Files: build.gradle